### PR TITLE
js: Support invalid javascript

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -23,7 +23,11 @@ module.exports = js;
 function js(str, ext, fn) {
   fn = fn || function() {};
 
-  var deps = detective(str);
+  try {
+    var deps = detective(str);
+  } catch (e) {
+    return [];
+  }
 
   // parse
   if (1 == arguments.length) return deps;

--- a/test/file-deps.js
+++ b/test/file-deps.js
@@ -45,6 +45,13 @@ describe('file-deps', function() {
       assert('foo' == deps.pop());
     })
 
+    it('should not throw when given invalid js', function(){
+      var js = 'require("foo")'
+             + '\n1=foo*bar+18,000!';
+      var deps = dep(js, 'js');
+      assert(0 == deps.length);
+    })
+
     it('should parse css', function() {
       var deps = dep(fix.css, 'css');
       var order = ['/foo.css', '../bar.css', '../baz.css', 'crazy.css', '../bing.css', '../photo.png', '../photo.png', '../photoB.png', 'photoC.png', 'photoC.png', '../photoC.png', 'haha.png', 'whatever.jpg'];


### PR DESCRIPTION
When attempting to parse invalid javascript, the prior implementation
would throw.  This patch ignores errors and returns an empty array of
`deps` instead.

Closes #4.
## 

@MatthewMueller I've only pushed this patch up because you've asked for it.  IMO, failing silently is _never_ the right thing to do.
